### PR TITLE
make prewview platform linux update

### DIFF
--- a/bin/preview.js
+++ b/bin/preview.js
@@ -10,6 +10,29 @@ var docroot = path.relative(process.cwd(), conf.publicDir);
 
 var rl = readline.createInterface(process.stdin, process.stdout, null);
 
+/**
+ * process execute
+ *
+ * @param {Number} port
+ * @author nanhapark
+ */
+function StandAlone(port) {
+  var spawn = require('child_process').spawn,
+      web    = spawn('locally', ['-w', docroot, '-p', port]);
+
+  web.stdout.on('data', function (data) {
+    console.log('haroo> stdout: ' + data);
+  });
+
+  web.stderr.on('data', function (data) {
+    console.log('haroo> stderr: ' + data);
+  });
+
+  web.on('exit', function (code) {
+    console.log('haroo> child process exited with code ' + code);
+  });
+}
+
 switch(process.platform) {
     case 'darwin' :
         console.log('haroo> Start server at http://localhost:8081 ¶'.yellow);
@@ -32,6 +55,18 @@ switch(process.platform) {
             process.stdin.destroy();
         });
 
+    break;
+    case 'linux' :
+
+        console.log('haroo> Start server at http://localhost:[port] ¶'.yellow);
+        if (path.existsSync(docroot) == false) {
+          console.error('haroo> not found ' + docroot);
+          process.exit(1);
+        }
+
+        rl.question('haroo> Input port number : ', function(port) {
+          StandAlone(port);
+        });
     break;
     case 'win32' :
     break;


### PR DESCRIPTION
현재 darwin platform 만 지원함.
child_process exec는 가끔 stdout, stderr 확인 할 수 없음.
child_process spawn 을 사용하여 함수 하나 추가함.

현재 make preview 할시 locally 떠 있는 상태이나
커맨드 상에는 아무런 메세지가 보여지지 않음.

rhio가 darwin부분은 수정해주기 바람.
