### PR TITLE
octopress 마이그레이션

### DIFF
--- a/bin/convert/octopress.js
+++ b/bin/convert/octopress.js
@@ -26,7 +26,7 @@ function mergeHead(source) {
     var prop,
         model = require('../_template/sample-post');
 
-    model.status = 'public';
+    model.status = 'publish';
     model.author = conf.meta.author;
 
     for(prop in source) {


### PR DESCRIPTION
octopress migration후 make gen 스크립트 실행시 변환된 페이지들은 생성되지 않는 문제가 있었어요 

내부적으로 'publish' 를 사용하고있는데 migration script에는 'public'으로 설정되어 변환시 if문에 안걸린듯 하네요 ^^; 
